### PR TITLE
Issue in PreviousButton + Solution (proposed and tested)

### DIFF
--- a/src/ProgressSteps/ProgressSteps.js
+++ b/src/ProgressSteps/ProgressSteps.js
@@ -45,7 +45,9 @@ class ProgressSteps extends Component {
 
   // Callback function from ProgressStep that passes current step.
   setActiveStep = step => {
-    this.setState({ activeStep: step });
+    if(step > -1){
+      this.setState({ activeStep: step });
+    }
   };
 
   render() {


### PR DESCRIPTION
## Expected Behavior
I'm in the last step, and I press the "previous" button several times, to go from the last step (position: 6) to the first (position: 0)

## Current Behavior
We got to the first screen and immediately afterwards it shows a React.cloneElement error (trying to clone an 'undefined' element)

## Steps to Reproduce
1. Create a component with '6' ProgresStep.
2. Press the 'Next' button until going to the step in position '6', 5 times in total.
3. Press the 'Previous' button at least '6' times (at least 1 more time than we have previously done)
4. When you get to the first screen, after, throw the error

## Possible Solution (And tested)
Avoid that the position of the active step is not below the first (0)

## Detailed Description
If we prevent the position of the active-step from being less than 0, it wouldn't throw the exception when React.cloneElement was called because it would always call the first step.

## Possible Implementation
```javascript
  setActiveStep = step => {
      this.setState({ activeStep: step });
  };
```

to 

```javascript
  setActiveStep = step => {
    if(step > -1){
      this.setState({ activeStep: step });
    }
  };
```