### PR TITLE
react-native-progress-steps Prop updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ render() {
 | previousBtnDisabled | Value to disable/enable previous button | false | Boolean |
 | scrollViewProps | Object to provide props to ScrollView component | {} | Object |
 | errors | Used to assist with current step validation. If true, the next step won't be rendered | false | Boolean |
+| removeButtonRow | Used to render the progress step without the button row | false | Boolean |
 
 ## Contributing
 Pull requests are always welcome! Feel free to open a new GitHub issue for any changes that can be made.

--- a/README.md
+++ b/README.md
@@ -129,32 +129,31 @@ render() {
 ## Documentation
 
 ### Progress Steps Component
-| Name                      | Description                                               | Default     | Type    |
-|---------------------------|-----------------------------------------------------------|-------------|---------|
-| borderWidth               | Width of the progress bar between steps                   | 6           | Number  |
-| borderStyle               | Type of border for the progress bar                       | solid       | String  |
-| activeStepIconBorderColor | Outside border color for the active step                  | #4bb543     | String  |
-| progressBarColor          | Color of the default progress bar                         | #ebebe4     | String  |
-| completedProgressBarColor | Color of the completed progress bar                       | #4bb543     | String  |
-| failedProgressBarColor    | Color of the failed progress bar                          | #ED696D     | String  |
-| activeStepIconColor       | Color of the active step icon                             | transparent | String  |
-| completedStepIconColor    | Color of the completed step icon                          | #4bb543     | String  |
-| disabledStepIconColor     | Color of the disabled step icon                           | #ebebe4     | String  |
-| failedStepIconColor       | Color of the failed step icon                             | #ED696D     | String  |
-| labelFontFamily           | Font family for the step icon label                       | iOS/Android default font | String |
-| labelColor                | Color of the default label                                | lightgray   | String  |
-| activeLabelColor          | Color of the active label                                 | #4bb543     | String  |
-| completedLabelColor       | Color of the completed label                              | lightgray   | String  |
-| failedLabelColor          | Color of the failed label                                 | lightgray   | String  |
-| activeStepNumColor        | Color of the active step number                           | black       | String  |
-| completedStepNumColor     | Color of the completed step number                        | black       | String  |
-| disabledStepNumColor      | Color of the disabled step number                         | white       | String  |
-| failedStepNumColor        | Color of the failed step number                           | white       | String  |
-| completedCheckColor       | Color of the completed step checkmark                     | white       | String  |
-| failedCrossColor          | Color of the failed  step cross                           | white       | String  |
-| activeStep                | Manually specify the active step                          | 0           | Number  |
-| isComplete                | Set all Steps to active state (overridden by hasFailures) | false       | Boolean |
-| hasFailures               | Set all Steps to failed state (overrides isComplete)      | false       | Boolean |
+| Name                      | Description                              | Default     | Type    |
+|---------------------------|------------------------------------------|-------------|---------|
+| borderWidth               | Width of the progress bar between steps  | 6           | Number  |
+| borderStyle               | Type of border for the progress bar      | solid       | String  |
+| activeStepIconBorderColor | Outside border color for the active step | #4bb543     | String  |
+| progressBarColor          | Color of the default progress bar        | #ebebe4     | String  |
+| completedProgressBarColor | Color of the completed progress bar      | #4bb543     | String  |
+| failedProgressBarColor    | Color of the failed progress bar         | #ED696D     | String  |
+| activeStepIconColor       | Color of the active step icon            | transparent | String  |
+| completedStepIconColor    | Color of the completed step icon         | #4bb543     | String  |
+| disabledStepIconColor     | Color of the disabled step icon          | #ebebe4     | String  |
+| failedStepIconColor       | Color of the failed step icon            | #ED696D     | String  |
+| labelFontFamily           | Font family for the step icon label      | iOS/Android default font | String |
+| labelColor                | Color of the default label               | lightgray   | String  |
+| activeLabelColor          | Color of the active label                | #4bb543     | String  |
+| completedLabelColor       | Color of the completed label             | lightgray   | String  |
+| failedLabelColor          | Color of the failed label                | lightgray   | String  |
+| activeStepNumColor        | Color of the active step number          | black       | String  |
+| completedStepNumColor     | Color of the completed step number       | black       | String  |
+| disabledStepNumColor      | Color of the disabled step number        | white       | String  |
+| failedStepNumColor        | Color of the failed step number          | white       | String  |
+| completedCheckColor       | Color of the completed step checkmark    | white       | String  |
+| failedCrossColor          | Color of the failed  step cross          | white       | String  |
+| activeStep                | Manually specify the active step         | 0           | Number  |
+| isComplete                | Set all Steps to active state            | false       | Boolean |
 
 ### Progress Step Component
 | Name | Description | Default | Type |

--- a/README.md
+++ b/README.md
@@ -129,26 +129,32 @@ render() {
 ## Documentation
 
 ### Progress Steps Component
-| Name                      | Description                               | Default     | Type    |
-|---------------------------|-------------------------------------------|-------------|---------|
-| borderWidth               | Width of the progress bar between steps   | 6           | Number  |
-| borderStyle               | Type of border for the progress bar       | solid       | String  |
-| activeStepIconBorderColor | Outside border color for the active step  | #4bb543     | String  |
-| progressBarColor          | Color of the default progress bar         | #ebebe4     | String  |
-| completedProgressBarColor | Color of the completed progress bar       | #4bb543     | String  |
-| activeStepIconColor       | Color of the active step icon             | transparent | String  |
-| completedStepIconColor    | Color of the completed step icon          | #4bb543     | String  |
-| disabledStepIconColor     | Color of the disabled step icon           | #ebebe4     | String  |
-| labelFontFamily           | Font family for the step icon label       | iOS/Android default font | String |
-| labelColor                | Color of the default label                | lightgray   | String  |
-| activeLabelColor          | Color of the active label                 | #4bb543     | String  |
-| completedLabelColor       | Color of the completed label              | lightgray   | String  |
-| activeStepNumColor        | Color of the active step number           | black       | String  |
-| completedStepNumColor     | Color of the completed step number        | black       | String  |
-| disabledStepNumColor      | Color of the disabled step number         | white       | String  |
-| completedCheckColor       | Color of the completed step checkmark     | white       | String  |
-| activeStep                | Manually specify the active step          | 0           | Number  |
-| isComplete                | Manually set all children to active state | false       | Boolean |
+| Name                      | Description                                               | Default     | Type    |
+|---------------------------|-----------------------------------------------------------|-------------|---------|
+| borderWidth               | Width of the progress bar between steps                   | 6           | Number  |
+| borderStyle               | Type of border for the progress bar                       | solid       | String  |
+| activeStepIconBorderColor | Outside border color for the active step                  | #4bb543     | String  |
+| progressBarColor          | Color of the default progress bar                         | #ebebe4     | String  |
+| completedProgressBarColor | Color of the completed progress bar                       | #4bb543     | String  |
+| failedProgressBarColor    | Color of the failed progress bar                          | #ED696D     | String  |
+| activeStepIconColor       | Color of the active step icon                             | transparent | String  |
+| completedStepIconColor    | Color of the completed step icon                          | #4bb543     | String  |
+| disabledStepIconColor     | Color of the disabled step icon                           | #ebebe4     | String  |
+| failedStepIconColor       | Color of the failed step icon                             | #ED696D     | String  |
+| labelFontFamily           | Font family for the step icon label                       | iOS/Android default font | String |
+| labelColor                | Color of the default label                                | lightgray   | String  |
+| activeLabelColor          | Color of the active label                                 | #4bb543     | String  |
+| completedLabelColor       | Color of the completed label                              | lightgray   | String  |
+| failedLabelColor          | Color of the failed label                                 | lightgray   | String  |
+| activeStepNumColor        | Color of the active step number                           | black       | String  |
+| completedStepNumColor     | Color of the completed step number                        | black       | String  |
+| disabledStepNumColor      | Color of the disabled step number                         | white       | String  |
+| failedStepNumColor        | Color of the failed step number                           | white       | String  |
+| completedCheckColor       | Color of the completed step checkmark                     | white       | String  |
+| failedCrossColor          | Color of the failed  step cross                           | white       | String  |
+| activeStep                | Manually specify the active step                          | 0           | Number  |
+| isComplete                | Set all Steps to active state (overridden by hasFailures) | false       | Boolean |
+| hasFailures               | Set all Steps to failed state (overrides isComplete)      | false       | Boolean |
 
 ### Progress Step Component
 | Name | Description | Default | Type |

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ render() {
 | labelFontFamily           | Font family for the step icon label      | iOS/Android default font | String |
 | labelColor                | Color of the default label               | lightgray   | String |
 | activeLabelColor          | Color of the active label                | #4bb543     | String |
+| completedLabelColor       | Color of the completed label             | lightgray   | String |
 | activeStepNumColor        | Color of the active step number          | black       | String |
 | completedStepNumColor     | Color of the completed step number       | black       | String |
 | disabledStepNumColor      | Color of the disabled step number        | white       | String |

--- a/README.md
+++ b/README.md
@@ -136,22 +136,17 @@ render() {
 | activeStepIconBorderColor | Outside border color for the active step | #4bb543     | String  |
 | progressBarColor          | Color of the default progress bar        | #ebebe4     | String  |
 | completedProgressBarColor | Color of the completed progress bar      | #4bb543     | String  |
-| failedProgressBarColor    | Color of the failed progress bar         | #ED696D     | String  |
 | activeStepIconColor       | Color of the active step icon            | transparent | String  |
 | completedStepIconColor    | Color of the completed step icon         | #4bb543     | String  |
 | disabledStepIconColor     | Color of the disabled step icon          | #ebebe4     | String  |
-| failedStepIconColor       | Color of the failed step icon            | #ED696D     | String  |
 | labelFontFamily           | Font family for the step icon label      | iOS/Android default font | String |
 | labelColor                | Color of the default label               | lightgray   | String  |
 | activeLabelColor          | Color of the active label                | #4bb543     | String  |
 | completedLabelColor       | Color of the completed label             | lightgray   | String  |
-| failedLabelColor          | Color of the failed label                | lightgray   | String  |
 | activeStepNumColor        | Color of the active step number          | black       | String  |
 | completedStepNumColor     | Color of the completed step number       | black       | String  |
 | disabledStepNumColor      | Color of the disabled step number        | white       | String  |
-| failedStepNumColor        | Color of the failed step number          | white       | String  |
 | completedCheckColor       | Color of the completed step checkmark    | white       | String  |
-| failedCrossColor          | Color of the failed  step cross          | white       | String  |
 | activeStep                | Manually specify the active step         | 0           | Number  |
 | isComplete                | Set all Steps to active state            | false       | Boolean |
 

--- a/README.md
+++ b/README.md
@@ -129,25 +129,26 @@ render() {
 ## Documentation
 
 ### Progress Steps Component
-| Name                      | Description                              | Default     | Type   |
-|---------------------------|------------------------------------------|-------------|--------|
-| borderWidth               | Width of the progress bar between steps  | 6           | Number |
-| borderStyle               | Type of border for the progress bar      | solid       | String |
-| activeStepIconBorderColor | Outside border color for the active step | #4bb543     | String |
-| progressBarColor          | Color of the default progress bar        | #ebebe4     | String |
-| completedProgressBarColor | Color of the completed progress bar      | #4bb543     | String |
-| activeStepIconColor       | Color of the active step icon            | transparent | String |
-| completedStepIconColor    | Color of the completed step icon         | #4bb543     | String |
-| disabledStepIconColor     | Color of the disabled step icon          | #ebebe4     | String |
-| labelFontFamily           | Font family for the step icon label      | iOS/Android default font | String |
-| labelColor                | Color of the default label               | lightgray   | String |
-| activeLabelColor          | Color of the active label                | #4bb543     | String |
-| completedLabelColor       | Color of the completed label             | lightgray   | String |
-| activeStepNumColor        | Color of the active step number          | black       | String |
-| completedStepNumColor     | Color of the completed step number       | black       | String |
-| disabledStepNumColor      | Color of the disabled step number        | white       | String |
-| completedCheckColor       | Color of the completed step checkmark    | white       | String |
-| activeStep                | Manually specify the active step         | 0           | Number |
+| Name                      | Description                               | Default     | Type    |
+|---------------------------|-------------------------------------------|-------------|---------|
+| borderWidth               | Width of the progress bar between steps   | 6           | Number  |
+| borderStyle               | Type of border for the progress bar       | solid       | String  |
+| activeStepIconBorderColor | Outside border color for the active step  | #4bb543     | String  |
+| progressBarColor          | Color of the default progress bar         | #ebebe4     | String  |
+| completedProgressBarColor | Color of the completed progress bar       | #4bb543     | String  |
+| activeStepIconColor       | Color of the active step icon             | transparent | String  |
+| completedStepIconColor    | Color of the completed step icon          | #4bb543     | String  |
+| disabledStepIconColor     | Color of the disabled step icon           | #ebebe4     | String  |
+| labelFontFamily           | Font family for the step icon label       | iOS/Android default font | String |
+| labelColor                | Color of the default label                | lightgray   | String  |
+| activeLabelColor          | Color of the active label                 | #4bb543     | String  |
+| completedLabelColor       | Color of the completed label              | lightgray   | String  |
+| activeStepNumColor        | Color of the active step number           | black       | String  |
+| completedStepNumColor     | Color of the completed step number        | black       | String  |
+| disabledStepNumColor      | Color of the disabled step number         | white       | String  |
+| completedCheckColor       | Color of the completed step checkmark     | white       | String  |
+| activeStep                | Manually specify the active step          | 0           | Number  |
+| isComplete                | Manually set all children to active state | false       | Boolean |
 
 ### Progress Step Component
 | Name | Description | Default | Type |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ render() {
 | previousBtnDisabled | Value to disable/enable previous button | false | Boolean |
 | scrollViewProps | Object to provide props to ScrollView component | {} | Object |
 | errors | Used to assist with current step validation. If true, the next step won't be rendered | false | Boolean |
-| removeButtonRow | Used to render the progress step without the button row | false | Boolean |
+| removeBtnRow | Used to render the progress step without the button row | false | Boolean |
 
 ## Contributing
 Pull requests are always welcome! Feel free to open a new GitHub issue for any changes that can be made.

--- a/src/ProgressSteps/ProgressStep.js
+++ b/src/ProgressSteps/ProgressStep.js
@@ -88,12 +88,18 @@ class ProgressStep extends Component {
 
   render() {
     const scrollViewProps = this.props.scrollViewProps || {};
+    const buttonRow = this.props.removeButtonRow ? null : (
+      <ProgressButtons 
+        renderNextButton={this.renderNextButton} 
+        renderPreviousButton={this.renderPreviousButton} 
+      />
+    );
 
     return (
       <View style={{ flex: 1 }}>
         <ScrollView {...scrollViewProps}>{this.props.children}</ScrollView>
 
-        <ProgressButtons renderNextButton={this.renderNextButton} renderPreviousButton={this.renderPreviousButton} />
+        {buttonRow}
       </View>
     );
   }
@@ -116,7 +122,8 @@ ProgressStep.propTypes = {
   previousBtnTextStyle: PropTypes.object,
   previousBtnDisabled: PropTypes.bool,
   scrollViewProps: PropTypes.object,
-  errors: PropTypes.bool
+  errors: PropTypes.bool,
+  removeButtonRow: PropTypes.bool
 };
 
 ProgressStep.defaultProps = {
@@ -125,7 +132,8 @@ ProgressStep.defaultProps = {
   finishBtnText: 'Submit',
   nextBtnDisabled: false,
   previousBtnDisabled: false,
-  errors: false
+  errors: false,
+  removeButtonRow: false
 };
 
 export default ProgressStep;

--- a/src/ProgressSteps/ProgressStep.js
+++ b/src/ProgressSteps/ProgressStep.js
@@ -88,7 +88,7 @@ class ProgressStep extends Component {
 
   render() {
     const scrollViewProps = this.props.scrollViewProps || {};
-    const buttonRow = this.props.removeButtonRow ? null : (
+    const buttonRow = this.props.removeBtnRow ? null : (
       <ProgressButtons 
         renderNextButton={this.renderNextButton} 
         renderPreviousButton={this.renderPreviousButton} 
@@ -123,7 +123,7 @@ ProgressStep.propTypes = {
   previousBtnDisabled: PropTypes.bool,
   scrollViewProps: PropTypes.object,
   errors: PropTypes.bool,
-  removeButtonRow: PropTypes.bool
+  removeBtnRow: PropTypes.bool
 };
 
 ProgressStep.defaultProps = {
@@ -133,7 +133,7 @@ ProgressStep.defaultProps = {
   nextBtnDisabled: false,
   previousBtnDisabled: false,
   errors: false,
-  removeButtonRow: false
+  removeBtnRow: false
 };
 
 export default ProgressStep;

--- a/src/ProgressSteps/ProgressSteps.js
+++ b/src/ProgressSteps/ProgressSteps.js
@@ -6,11 +6,18 @@ import StepIcon from './StepIcon';
 
 class ProgressSteps extends Component {
   state = {
-    stepCount: 0
+    stepCount: 0,
+    activeStep: this.props.activeStep
   };
 
   componentDidMount() {
     this.setState({ stepCount: React.Children.count(this.props.children) });
+  }
+
+  componentWillUpdate(prevProps) {
+    if(prevProps.activeStep !== this.props.activeStep){
+      this.setActiveStep(this.props.activeStep);
+    }
   }
 
   getChildProps() {
@@ -21,13 +28,15 @@ class ProgressSteps extends Component {
     let step = [];
 
     times(this.state.stepCount, i => {
-      const isCompletedStep = this.props.isComplete && !this.props.hasFailures
-        ? true 
-        : i < this.props.activeStep;
+      const isCompletedStep = this.props.hasFailures
+        ? false
+        : this.props.isComplete
+          ? true 
+          : i < this.state.activeStep;
         
       const isActiveStep = this.props.isComplete || this.props.hasFailures
         ? false 
-        : i === this.props.activeStep;
+        : i === this.state.activeStep;
 
       step.push(
         <View key={i}>
@@ -73,9 +82,9 @@ class ProgressSteps extends Component {
       <View style={{ flex: 1 }}>
         <View style={styles.stepIcons}>{this.renderStepIcons()}</View>
         <View style={{ flex: 1 }}>
-          {React.cloneElement(this.props.children[this.props.activeStep], {
+          {React.cloneElement(this.props.children[this.state.activeStep], {
             setActiveStep: this.setActiveStep,
-            activeStep: this.props.activeStep,
+            activeStep: this.state.activeStep,
             stepCount: this.state.stepCount
           })}
         </View>

--- a/src/ProgressSteps/ProgressSteps.js
+++ b/src/ProgressSteps/ProgressSteps.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { View } from 'react-native';
 import { times } from 'lodash';
-
+import PropTypes from 'prop-types';
 import StepIcon from './StepIcon';
 
 class ProgressSteps extends Component {
@@ -22,6 +22,14 @@ class ProgressSteps extends Component {
     let step = [];
 
     times(this.state.stepCount, i => {
+      const isCompletedStep = this.props.isComplete 
+        ? true 
+        : i < this.state.activeStep;
+        
+      const isActiveStep = this.props.isComplete 
+        ? false 
+        : i === this.state.activeStep;
+
       step.push(
         <View key={i}>
           <View>
@@ -31,8 +39,8 @@ class ProgressSteps extends Component {
               label={this.props.children[i].props.label}
               isFirstStep={i === 0}
               isLastStep={i === this.state.stepCount - 1}
-              isCompletedStep={i < this.state.activeStep}
-              isActiveStep={i === this.state.activeStep}
+              isCompletedStep={isCompletedStep}
+              isActiveStep={isActiveStep}
             />
           </View>
         </View>
@@ -75,5 +83,13 @@ class ProgressSteps extends Component {
     );
   }
 }
+
+ProgressSteps.propTypes = {
+  isComplete: PropTypes.bool
+};
+
+ProgressSteps.defaultProps = {
+  isComplete: false
+};
 
 export default ProgressSteps;

--- a/src/ProgressSteps/ProgressSteps.js
+++ b/src/ProgressSteps/ProgressSteps.js
@@ -28,13 +28,11 @@ class ProgressSteps extends Component {
     let step = [];
 
     times(this.state.stepCount, i => {
-      const isCompletedStep = this.props.hasFailures
-        ? false
-        : this.props.isComplete
-          ? true 
-          : i < this.state.activeStep;
+      const isCompletedStep = this.props.isComplete
+        ? true 
+        : i < this.state.activeStep;
         
-      const isActiveStep = this.props.isComplete || this.props.hasFailures
+      const isActiveStep = this.props.isComplete
         ? false 
         : i === this.state.activeStep;
 
@@ -49,7 +47,6 @@ class ProgressSteps extends Component {
               isLastStep={i === this.state.stepCount - 1}
               isCompletedStep={isCompletedStep}
               isActiveStep={isActiveStep}
-              isFailedStep={this.props.hasFailures}
             />
           </View>
         </View>
@@ -95,14 +92,12 @@ class ProgressSteps extends Component {
 
 ProgressSteps.propTypes = {
   isComplete: PropTypes.bool,
-  activeStep: PropTypes.number,
-  hasFailures: PropTypes.bool
+  activeStep: PropTypes.number
 };
 
 ProgressSteps.defaultProps = {
   isComplete: false,
-  activeStep: 0,
-  hasFailures: false
+  activeStep: 0
 };
 
 export default ProgressSteps;

--- a/src/ProgressSteps/ProgressSteps.js
+++ b/src/ProgressSteps/ProgressSteps.js
@@ -21,13 +21,11 @@ class ProgressSteps extends Component {
     let step = [];
 
     times(this.state.stepCount, i => {
-      const isFailedStep = this.props.failedSteps.includes(i);
-
-      const isCompletedStep = this.props.isComplete && !isFailedStep
+      const isCompletedStep = this.props.isComplete && !this.props.hasFailures
         ? true 
         : i < this.props.activeStep;
         
-      const isActiveStep = this.props.isComplete 
+      const isActiveStep = this.props.isComplete || this.props.hasFailures
         ? false 
         : i === this.props.activeStep;
 
@@ -42,7 +40,7 @@ class ProgressSteps extends Component {
               isLastStep={i === this.state.stepCount - 1}
               isCompletedStep={isCompletedStep}
               isActiveStep={isActiveStep}
-              isFailedStep={isFailedStep}
+              isFailedStep={this.props.hasFailures}
             />
           </View>
         </View>
@@ -89,13 +87,13 @@ class ProgressSteps extends Component {
 ProgressSteps.propTypes = {
   isComplete: PropTypes.bool,
   activeStep: PropTypes.number,
-  failedSteps: PropTypes.array
+  hasFailures: PropTypes.bool
 };
 
 ProgressSteps.defaultProps = {
   isComplete: false,
   activeStep: 0,
-  failedSteps: []
+  hasFailures: false
 };
 
 export default ProgressSteps;

--- a/src/ProgressSteps/ProgressSteps.js
+++ b/src/ProgressSteps/ProgressSteps.js
@@ -21,7 +21,7 @@ class ProgressSteps extends Component {
     let step = [];
 
     times(this.state.stepCount, i => {
-      const isFailedStep = this.props.failedSteps.incudes(i);
+      const isFailedStep = this.props.failedSteps.includes(i);
 
       const isCompletedStep = this.props.isComplete && !isFailedStep
         ? true 

--- a/src/ProgressSteps/ProgressSteps.js
+++ b/src/ProgressSteps/ProgressSteps.js
@@ -21,7 +21,9 @@ class ProgressSteps extends Component {
     let step = [];
 
     times(this.state.stepCount, i => {
-      const isCompletedStep = this.props.isComplete 
+      const isFailedStep = this.props.failedSteps.incudes(i);
+
+      const isCompletedStep = this.props.isComplete && !isFailedStep
         ? true 
         : i < this.props.activeStep;
         
@@ -40,6 +42,7 @@ class ProgressSteps extends Component {
               isLastStep={i === this.state.stepCount - 1}
               isCompletedStep={isCompletedStep}
               isActiveStep={isActiveStep}
+              isFailedStep={isFailedStep}
             />
           </View>
         </View>
@@ -85,12 +88,14 @@ class ProgressSteps extends Component {
 
 ProgressSteps.propTypes = {
   isComplete: PropTypes.bool,
-  activeStep: PropTypes.number
+  activeStep: PropTypes.number,
+  failedSteps: PropTypes.array
 };
 
 ProgressSteps.defaultProps = {
   isComplete: false,
-  activeStep: 0
+  activeStep: 0,
+  failedSteps: []
 };
 
 export default ProgressSteps;

--- a/src/ProgressSteps/ProgressSteps.js
+++ b/src/ProgressSteps/ProgressSteps.js
@@ -6,8 +6,7 @@ import StepIcon from './StepIcon';
 
 class ProgressSteps extends Component {
   state = {
-    stepCount: 0,
-    activeStep: this.props.activeStep || 0
+    stepCount: 0
   };
 
   componentDidMount() {
@@ -24,11 +23,11 @@ class ProgressSteps extends Component {
     times(this.state.stepCount, i => {
       const isCompletedStep = this.props.isComplete 
         ? true 
-        : i < this.state.activeStep;
+        : i < this.props.activeStep;
         
       const isActiveStep = this.props.isComplete 
         ? false 
-        : i === this.state.activeStep;
+        : i === this.props.activeStep;
 
       step.push(
         <View key={i}>
@@ -73,9 +72,9 @@ class ProgressSteps extends Component {
       <View style={{ flex: 1 }}>
         <View style={styles.stepIcons}>{this.renderStepIcons()}</View>
         <View style={{ flex: 1 }}>
-          {React.cloneElement(this.props.children[this.state.activeStep], {
+          {React.cloneElement(this.props.children[this.props.activeStep], {
             setActiveStep: this.setActiveStep,
-            activeStep: this.state.activeStep,
+            activeStep: this.props.activeStep,
             stepCount: this.state.stepCount
           })}
         </View>
@@ -85,11 +84,13 @@ class ProgressSteps extends Component {
 }
 
 ProgressSteps.propTypes = {
-  isComplete: PropTypes.bool
+  isComplete: PropTypes.bool,
+  activeStep: PropTypes.number
 };
 
 ProgressSteps.defaultProps = {
-  isComplete: false
+  isComplete: false,
+  activeStep: 0
 };
 
 export default ProgressSteps;

--- a/src/ProgressSteps/ProgressSteps.js
+++ b/src/ProgressSteps/ProgressSteps.js
@@ -14,7 +14,7 @@ class ProgressSteps extends Component {
     this.setState({ stepCount: React.Children.count(this.props.children) });
   }
 
-  componentWillUpdate(prevProps) {
+  componentDidUpdate(prevProps) {
     if(prevProps.activeStep !== this.props.activeStep){
       this.setActiveStep(this.props.activeStep);
     }

--- a/src/ProgressSteps/StepIcon.js
+++ b/src/ProgressSteps/StepIcon.js
@@ -59,9 +59,7 @@ class StepIcon extends Component {
           width: 36,
           height: 36,
           borderRadius: 18,
-          backgroundColor: this.props.completedStepIconColor,
-          borderColor: this.props.completedStepIconColor,
-          borderWidth: 5,
+          backgroundColor: this.props.completedStepIconColor
         },
         circleText: {
           alignSelf: 'center',

--- a/src/ProgressSteps/StepIcon.js
+++ b/src/ProgressSteps/StepIcon.js
@@ -59,7 +59,9 @@ class StepIcon extends Component {
           width: 36,
           height: 36,
           borderRadius: 18,
-          backgroundColor: this.props.completedStepIconColor
+          backgroundColor: this.props.completedStepIconColor,
+          borderColor: this.props.completedStepIconColor,
+          borderWidth: 5,
         },
         circleText: {
           alignSelf: 'center',

--- a/src/ProgressSteps/StepIcon.js
+++ b/src/ProgressSteps/StepIcon.js
@@ -263,7 +263,7 @@ StepIcon.defaultProps = {
   labelColor: 'lightgray',
   activeLabelColor: '#4BB543',
   completedLabelColor: 'lightgray',
-  failedLabelColor: '#ED696D',
+  failedLabelColor: 'lightgray',
 
   activeStepNumColor: 'black',
   completedStepNumColor: 'black',

--- a/src/ProgressSteps/StepIcon.js
+++ b/src/ProgressSteps/StepIcon.js
@@ -98,6 +98,51 @@ class StepIcon extends Component {
           color: this.props.completedStepNumColor
         }
       };
+    } else if (this.props.isFailedStep) {
+      styles = {
+        circleStyle: {
+          width: 36,
+          height: 36,
+          borderRadius: 18,
+          backgroundColor: this.props.failedStepIconColor
+        },
+        circleText: {
+          alignSelf: 'center',
+          top: 18 / 2
+        },
+        labelText: {
+          textAlign: 'center',
+          flexWrap: 'wrap',
+          width: 100,
+          paddingTop: 2,
+          fontFamily: this.props.labelFontFamily,
+          color: this.props.failedLabelColor,
+          marginTop: 4
+        },
+        leftBar: {
+          position: 'absolute',
+          top: 36 / 2,
+          left: 0,
+          right: 36 + 8,
+          borderTopStyle: this.props.borderStyle,
+          borderTopWidth: this.props.borderWidth,
+          borderTopColor: this.props.failedProgressBarColor,
+          marginRight: 36 / 2 + 4
+        },
+        rightBar: {
+          position: 'absolute',
+          top: 36 / 2,
+          right: 0,
+          left: 36 + 8,
+          borderTopStyle: this.props.borderStyle,
+          borderTopWidth: this.props.borderWidth,
+          borderTopColor: this.props.failedProgressBarColor,
+          marginLeft: 36 / 2 + 4
+        },
+        stepNum: {
+          color: this.props.failedStepNumColor
+        }
+      };
     } else {
       styles = {
         circleStyle: {
@@ -151,6 +196,8 @@ class StepIcon extends Component {
           <Text style={styles.circleText}>
             {this.props.isCompletedStep ? (
               <Text style={{ color: this.props.completedCheckColor }}>&#10003;</Text>
+            ) : this.props.isFailedStep ? (
+              <Text style={{ color: this.props.failedCrossColor }}>&#10006;</Text>
             ) : (
               <Text style={styles.stepNum}>{this.props.stepNum}</Text>
             )}
@@ -177,21 +224,26 @@ StepIcon.propTypes = {
 
   progressBarColor: PropTypes.string,
   completedProgressBarColor: PropTypes.string,
+  failedProgressBarColor: PropTypes.string,
 
   activeStepIconColor: PropTypes.string,
   disabledStepIconColor: PropTypes.string,
   completedStepIconColor: PropTypes.string,
+  failedStepIconColor: PropTypes.string,
 
   labelFontFamily: PropTypes.string,
   labelColor: PropTypes.string,
   activeLabelColor: PropTypes.string,
   completedLabelColor: PropTypes.string,
+  failedLabelColor: PropTypes.string,
 
   activeStepNumColor: PropTypes.string,
   completedStepNumColor: PropTypes.string,
   disabledStepNumColor: PropTypes.string,
+  failedStepNumColor: PropTypes.string,
 
-  completedCheckColor: PropTypes.string
+  completedCheckColor: PropTypes.string,
+  failedCrossColor: PropTypes.string,
 };
 
 StepIcon.defaultProps = {
@@ -201,20 +253,25 @@ StepIcon.defaultProps = {
 
   progressBarColor: '#ebebe4',
   completedProgressBarColor: '#4BB543',
+  failedProgressBarColor: '#ED696D',
 
   activeStepIconColor: 'transparent',
   completedStepIconColor: '#4BB543',
   disabledStepIconColor: '#ebebe4',
+  failedStepIconColor: '#ED696D',
 
   labelColor: 'lightgray',
   activeLabelColor: '#4BB543',
   completedLabelColor: 'lightgray',
+  failedLabelColor: '#ED696D',
 
   activeStepNumColor: 'black',
   completedStepNumColor: 'black',
   disabledStepNumColor: 'white',
+  failedStepNumColor: 'black',
 
-  completedCheckColor: 'white'
+  completedCheckColor: 'white',
+  failedCrossColor: 'white',
 };
 
 export default StepIcon;

--- a/src/ProgressSteps/StepIcon.js
+++ b/src/ProgressSteps/StepIcon.js
@@ -98,51 +98,6 @@ class StepIcon extends Component {
           color: this.props.completedStepNumColor
         }
       };
-    } else if (this.props.isFailedStep) {
-      styles = {
-        circleStyle: {
-          width: 36,
-          height: 36,
-          borderRadius: 18,
-          backgroundColor: this.props.failedStepIconColor
-        },
-        circleText: {
-          alignSelf: 'center',
-          top: 18 / 2
-        },
-        labelText: {
-          textAlign: 'center',
-          flexWrap: 'wrap',
-          width: 100,
-          paddingTop: 2,
-          fontFamily: this.props.labelFontFamily,
-          color: this.props.failedLabelColor,
-          marginTop: 4
-        },
-        leftBar: {
-          position: 'absolute',
-          top: 36 / 2,
-          left: 0,
-          right: 36 + 8,
-          borderTopStyle: this.props.borderStyle,
-          borderTopWidth: this.props.borderWidth,
-          borderTopColor: this.props.failedProgressBarColor,
-          marginRight: 36 / 2 + 4
-        },
-        rightBar: {
-          position: 'absolute',
-          top: 36 / 2,
-          right: 0,
-          left: 36 + 8,
-          borderTopStyle: this.props.borderStyle,
-          borderTopWidth: this.props.borderWidth,
-          borderTopColor: this.props.failedProgressBarColor,
-          marginLeft: 36 / 2 + 4
-        },
-        stepNum: {
-          color: this.props.failedStepNumColor
-        }
-      };
     } else {
       styles = {
         circleStyle: {
@@ -196,8 +151,6 @@ class StepIcon extends Component {
           <Text style={styles.circleText}>
             {this.props.isCompletedStep ? (
               <Text style={{ color: this.props.completedCheckColor }}>&#10003;</Text>
-            ) : this.props.isFailedStep ? (
-              <Text style={{ color: this.props.failedCrossColor }}>&#10006;</Text>
             ) : (
               <Text style={styles.stepNum}>{this.props.stepNum}</Text>
             )}
@@ -224,26 +177,21 @@ StepIcon.propTypes = {
 
   progressBarColor: PropTypes.string,
   completedProgressBarColor: PropTypes.string,
-  failedProgressBarColor: PropTypes.string,
 
   activeStepIconColor: PropTypes.string,
   disabledStepIconColor: PropTypes.string,
   completedStepIconColor: PropTypes.string,
-  failedStepIconColor: PropTypes.string,
 
   labelFontFamily: PropTypes.string,
   labelColor: PropTypes.string,
   activeLabelColor: PropTypes.string,
   completedLabelColor: PropTypes.string,
-  failedLabelColor: PropTypes.string,
 
   activeStepNumColor: PropTypes.string,
   completedStepNumColor: PropTypes.string,
   disabledStepNumColor: PropTypes.string,
-  failedStepNumColor: PropTypes.string,
 
-  completedCheckColor: PropTypes.string,
-  failedCrossColor: PropTypes.string,
+  completedCheckColor: PropTypes.string
 };
 
 StepIcon.defaultProps = {
@@ -253,25 +201,20 @@ StepIcon.defaultProps = {
 
   progressBarColor: '#ebebe4',
   completedProgressBarColor: '#4BB543',
-  failedProgressBarColor: '#ED696D',
 
   activeStepIconColor: 'transparent',
   completedStepIconColor: '#4BB543',
   disabledStepIconColor: '#ebebe4',
-  failedStepIconColor: '#ED696D',
 
   labelColor: 'lightgray',
   activeLabelColor: '#4BB543',
   completedLabelColor: 'lightgray',
-  failedLabelColor: 'lightgray',
 
   activeStepNumColor: 'black',
   completedStepNumColor: 'black',
   disabledStepNumColor: 'white',
-  failedStepNumColor: 'black',
 
-  completedCheckColor: 'white',
-  failedCrossColor: 'white',
+  completedCheckColor: 'white'
 };
 
 export default StepIcon;

--- a/src/ProgressSteps/StepIcon.js
+++ b/src/ProgressSteps/StepIcon.js
@@ -71,7 +71,7 @@ class StepIcon extends Component {
           width: 100,
           paddingTop: 2,
           fontFamily: this.props.labelFontFamily,
-          color: this.props.labelColor,
+          color: this.props.completedLabelColor,
           marginTop: 4
         },
         leftBar: {
@@ -185,6 +185,7 @@ StepIcon.propTypes = {
   labelFontFamily: PropTypes.string,
   labelColor: PropTypes.string,
   activeLabelColor: PropTypes.string,
+  completedLabelColor: PropTypes.string,
 
   activeStepNumColor: PropTypes.string,
   completedStepNumColor: PropTypes.string,
@@ -207,6 +208,7 @@ StepIcon.defaultProps = {
 
   labelColor: 'lightgray',
   activeLabelColor: '#4BB543',
+  completedLabelColor: 'lightgray',
 
   activeStepNumColor: 'black',
   completedStepNumColor: 'black',


### PR DESCRIPTION
## Description
- Added `removeBtnRow` prop to `ProgressStep` so that the Buttons can be completely removed
- Added `componentDidUpdate` function to `ProgressSteps` so that `activeStep` prop can be used to programmatically update the current Step position
- Added `isComplete` prop to `ProgressSteps` so that a complete stage can be shown (All `ProgressSteps` set to completed).
![ProgressSteps](https://user-images.githubusercontent.com/9335768/78163318-2672ad00-7440-11ea-9acd-dcd50464f8cb.PNG)
-  Added `completedLabelColor` prop so that Completed labels can be set differently to Disabled labels
![ProgressSteps2](https://user-images.githubusercontent.com/9335768/78163746-b3b60180-7440-11ea-972b-0357b7091b8a.PNG)

NOTE: I am happy to split this up into separate PR's if needed -> I required all of the changes for a release at work.