### PR TITLE
Hotfix/fix progress bar overlaping step icon

### DIFF
--- a/src/ProgressSteps/StepIcon.js
+++ b/src/ProgressSteps/StepIcon.js
@@ -32,6 +32,7 @@ class StepIcon extends Component {
         },
         leftBar: {
           position: 'absolute',
+          zIndex: -1,
           top: 40 / 2.22,
           left: 0,
           right: 40 + 8,
@@ -42,6 +43,7 @@ class StepIcon extends Component {
         },
         rightBar: {
           position: 'absolute',
+          zIndex: -1,
           top: 40 / 2.22,
           right: 0,
           left: 40 + 8,
@@ -78,6 +80,7 @@ class StepIcon extends Component {
         },
         leftBar: {
           position: 'absolute',
+          zIndex: -1,
           top: 36 / 2,
           left: 0,
           right: 36 + 8,
@@ -88,6 +91,7 @@ class StepIcon extends Component {
         },
         rightBar: {
           position: 'absolute',
+          zIndex: -1,
           top: 36 / 2,
           right: 0,
           left: 36 + 8,
@@ -124,6 +128,7 @@ class StepIcon extends Component {
         },
         leftBar: {
           position: 'absolute',
+          zIndex: -1,
           top: 36 / 2,
           left: 0,
           right: 36 + 8,
@@ -134,6 +139,7 @@ class StepIcon extends Component {
         },
         rightBar: {
           position: 'absolute',
+          zIndex: -1,
           top: 36 / 2,
           right: 0,
           left: 36 + 8,


### PR DESCRIPTION
When the progress bar has a different color than the step icon, 
the progress bar overlaps the step icon.

To fix this, I added the `zIndex` property
to every `leftBar` and `rightBar` property inside the `StepIcon.js`
file.

[This is your current code](https://i.imgur.com/34wv6C8.png)
[This is my fix](https://i.imgur.com/3wdNRP3.png)