### PR TITLE
Adding scrollView reference to the list of properties.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-progress-steps",
-  "version": "1.2.8",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -807,9 +807,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/src/ProgressSteps/ProgressStep.js
+++ b/src/ProgressSteps/ProgressStep.js
@@ -100,7 +100,7 @@ class ProgressStep extends Component {
     return (
       <View style={{ flex: 1 }}>
         {isScrollable
-          ? <ScrollView {...scrollViewProps}>{this.props.children}</ScrollView>
+          ? <ScrollView {...scrollViewProps} ref={scrollViewRef}>{this.props.children}</ScrollView>
           : <View {...viewProps}>{this.props.children}</View>}
 
         {buttonRow}
@@ -126,6 +126,7 @@ ProgressStep.propTypes = {
   previousBtnTextStyle: PropTypes.object,
   previousBtnDisabled: PropTypes.bool,
   scrollViewProps: PropTypes.object,
+  scrollViewRef: PropTypes.object,
   viewProps: PropTypes.object,
   errors: PropTypes.bool,
   removeBtnRow: PropTypes.bool,

--- a/src/ProgressSteps/ProgressStep.js
+++ b/src/ProgressSteps/ProgressStep.js
@@ -100,7 +100,7 @@ class ProgressStep extends Component {
     return (
       <View style={{ flex: 1 }}>
         {isScrollable
-          ? <ScrollView {...scrollViewProps} ref={scrollViewRef}>{this.props.children}</ScrollView>
+          ? <ScrollView {...scrollViewProps} ref={this.props.scrollViewRef}>{this.props.children}</ScrollView>
           : <View {...viewProps}>{this.props.children}</View>}
 
         {buttonRow}


### PR DESCRIPTION
I added it to allow users control the scroll when navigate to the next, or previous step:

```
const nextStep = () => {
scrollStep.current?.scrollTo({
      y: 0,
      x: 0,
      animated: true,
    });
}
```
....
```
 <ProgressStep
          scrollViewRef={scrollStep1}
          label="Dados básicos"
          nextBtnText="Próximo"
          finishBtnText="Finalizar"
          previousBtnText="Voltar"
          errors={error}
          view
          onNext={nextStep(1)}
        >
```

https://user-images.githubusercontent.com/4740291/149039862-4d050044-bc1f-4b00-a6bb-a00361a72748.mov


